### PR TITLE
Update grammars/zvm-asm.cson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.2.1 - Recognize z/OS UNIX Assembler files
+* ASM: include file type 's' in the list of file types associated with ASM.
+
 ## 0.2.0 - Incremental improvements based on usage
 * PLX: treat @logic/endlogic as multiline comments
 * PLX: Apply highlighting to macro files too
 * PLX: When highlighting BIFs like Length(), highlight the name only (was highlighting the open paren too)
-* PLX: Many new snippets to insert common constructs like If, Select 
+* PLX: Many new snippets to insert common constructs like If, Select
 
 ## 0.1.0 - First Release
 * Basic assembler and PL/x syntax highlighting.  Plenty of TODOs in the grammar files.  Not all of them can be implemented given Atom's restrictions on hightlighters, which in some cases conflict with the language definitions.

--- a/grammars/zvm-asm.cson
+++ b/grammars/zvm-asm.cson
@@ -22,7 +22,7 @@
 
 'scopeName': 'source.zvmasm'
 'name': 'z/VM assembler'
-'fileTypes': ['ASM', 'asm','assemble','macro','repos']
+'fileTypes': ['ASM', 'asm','assemble','macro','repos','s']
 
 'patterns': [
     { 'include': '#line-too-long-rule' },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "language-zvm-asm",
   "main": "./lib/language-zvm-asm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Syntax highlighting for z/VM assembler language files",
   "keywords": [
     "language",


### PR DESCRIPTION
Update grammars/zvm-asm.cson to add 's' to fileTypes.
The z/OS XL C/C++ c89 and xlc commands recognizes file types of interest via file extension. c89 recognizes assembler source files in the z/OS UNIX file system by extension .s, as does xlc by default. See the following for details:

c89:
[https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.cbcux01/bpxa5c89.htm](url)

xlc:
[https://www.ibm.com/support/knowledgecenter/SSLTBW_2.3.0/com.ibm.zos.v2r3.cbcux01/cfgattr.htm](url)

Signed-off-by: Gord Tomlin gord.tomlin@gmail.com