### PR TITLE
Remove duplicate @Logic block

### DIFF
--- a/snippets/language-PLX.cson
+++ b/snippets/language-PLX.cson
@@ -121,13 +121,6 @@
   # https://github.com/atom/autocomplete-snippets/issues/56
   # https://github.com/atom/autocomplete-snippets/issues/67
   'Insert @Logic block':
-    'prefix': '@logic'
-    'body': """
-      @LOGIC;
-      $1
-      @ENDLOGIC;
-    """
-  'Insert @Logic block':
     'prefix': 'logic' # Intentionally omitted @ from first body line
     'body': """
       LOGIC;


### PR DESCRIPTION
When loading Atom, I received a warning that the @Logic block is a duplicate insert.  I found that there are two similar inserts right above each other.  After deleting one block, Atom loads fine.