### PR TITLE
Fix PLX snippet error message

### DIFF
--- a/snippets/language-PLX.cson
+++ b/snippets/language-PLX.cson
@@ -121,16 +121,9 @@
   # https://github.com/atom/autocomplete-snippets/issues/56
   # https://github.com/atom/autocomplete-snippets/issues/67
   'Insert @Logic block':
-    'prefix': '@logic'
+    'prefix': 'logic'
     'body': """
       @LOGIC;
-      $1
-      @ENDLOGIC;
-    """
-  'Insert @Logic block':
-    'prefix': 'logic' # Intentionally omitted @ from first body line
-    'body': """
-      LOGIC;
       $1
       @ENDLOGIC;
     """


### PR DESCRIPTION
resolves #6.
Issue: Discussed in #6 

Removing the second  `logic` block and changing the prefix to `logic` from `@logic` removes the error popup as well as enables the use of `logic` block