### PR TITLE
grammars/zvm-asm.cson TODOs fixes

### DIFF
--- a/grammars/zvm-asm.cson
+++ b/grammars/zvm-asm.cson
@@ -50,9 +50,8 @@
       'name': 'comment.line.zvmasm'
     },
     'register-variable-rule': {
-      # TODO Figure out why uncontinued-statement-rule overrides this, no matter which comes first in patterns[]
       'match': '\\b([R|r]([0-9]|1[0-5]))\\b'
-      'name':  'keyword.operator.zvmasm'
+      'name':  'variable.parameter.zvmasm'
     },
     'register-equate-rule': {
       # * >> + on whitespace after EQU

--- a/grammars/zvm-asm.cson
+++ b/grammars/zvm-asm.cson
@@ -94,12 +94,15 @@
       'name': 'comment.line.zvmasm'
     },
     'continuation-line-rule': {
-      # TODO See if lookahead could be used to distinguish comments from operands
-      'match': '^[ ]{15}([A-Za-z0-9@$#_+-,=.*()\'/&]+)([ ]+.*)?'
+      # Regex will start by searching for '*' then check if line is terminated and from the next line,
+      # check for 15 spaces followed by syntax matchings.
+      'match': '(\\*\\n[ ]{15})([A-Za-z0-9@$#_+-,=.*()\'\/&]+)([ ]+.*)?'
       'captures':
-          #'1': # Continued operands, leave as normal source by default
+          '1':
+              'name': 'comment.character.zvmasm'
           '2': # remarks
               'name': 'comment.line.zvmasm'
+          # '3': operands. leave as normal source be default
     },
     'uncontinued-statement-rule': {
       # TODO Handle corner cases where space does not signal end of operands

--- a/grammars/zvm-asm.cson
+++ b/grammars/zvm-asm.cson
@@ -39,9 +39,8 @@
 
 'repository': {
     'line-too-long-rule': {
-      # Anything over 80 characters makes line come up red
-      # TODO really want this test to be >72 plus anything BUT a sequence number or blanks
-      'match': '.*(?<=.{80}).+'
+      # Anything over 80 characters makes line come up red except 8 trailing digits
+      'match': '.*(?<=.{72})(([^0-9 \\r\\n]+)|([0-9 \\r\\n]{8}.+))'
       'name': 'invalid.illegal.zvmasm'
     },
     'sequence-number-rule': {


### PR DESCRIPTION
- [abda78d](https://github.com/openmainframeproject/atompkg-language-zvm-asm/commit/abda78d5918127cf56b429e9d553f429c71497b6): `keyword.operator.zvmasm` dosen't match the pattern syntax. Since the pattern matches a variable, `variable.parameter.zvmasm` is a better fit. Reference for [naming conventions](https://macromates.com/manual/en/language_grammars#language_rules).
- [9292530](https://github.com/openmainframeproject/atompkg-language-zvm-asm/commit/9292530847711c6753f47b0063329a6f58344c38): this pattern rule is pretty much the same as in the `line-too-long-rule` from [grammars/zvm-plx.cson](https://github.com/openmainframeproject/atompkg-language-zvm-asm/blob/bfd3fb1a59ddbc46d558aeeb4ba5517df11035a8/grammars/zvm-plx.cson#L86)
- ~[06bf198](https://github.com/openmainframeproject/atompkg-language-zvm-asm/pull/12/commits/06bf198a9d58850512c362ee3d4ca7e0c1614dc7): null commit. deleted~
- [75b8196](https://github.com/openmainframeproject/atompkg-language-zvm-asm/pull/12/commits/75b8196582262393981c93fbd1d7811c67c285c2): instead of using a regex rule to find the `*` from previous line at 72nd position, the regex could be altered to check for 71 characters, one `*`, `\n` and consecutively the next line.